### PR TITLE
hanime1.me and rule34video.com support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__
 *.pyc
 venv/
 dist/
+.idea/
+/browser-profile/
+/tests/.pytest_cache/
+/tests/output/

--- a/README.md
+++ b/README.md
@@ -34,19 +34,28 @@ irm https://deno.land/install.ps1 | iex
 
 The following is the support matrix of sites and the respective video resolutions offered. **To request support for a site, or complain about a broken site, please open a [Github issue](https://github.com/cynthia2006/hanime-plugin/issues).**
 
-|                 | 720p  | 1080p | 4K    |
-| --------------- | ----- | ----- | ----- |
-| hstream.moe     | ✅    | ✅ †  | ✅ †  |
-| oppai.stream    | ✅    | ✅ ‡  | ✅ ‡  |
-| hentaihaven.com | ✅    | ✅    | ❌     |
-| hanime.tv       | ✅    | ❌*    | ❌     |
-| ohentai.org     | ✅    | ❌     | ❌     |
-| hentaimama.io   | ✅    | ❌     | ❌     |
-| hanime.red      | ❌     | ✅    | ❌     |
+|                 | 720p  | 1080p | 4K   |
+| --------------- | ----- | ----- | ---- |
+| hstream.moe     | ✅    | ✅ †  | ✅ † |
+| oppai.stream    | ✅    | ✅ ‡  | ✅ ‡ |
+| hentaihaven.com | ✅    | ✅    | ❌    |
+| hanime.tv       | ✅    | ❌*    | ❌    |
+| hanime1.me      | ✅    | ✅    | ❌    |
+| rule34video.com | ✅    | ✅    | ✅   |
+| ohentai.org     | ✅    | ❌     | ❌    |
+| hentaimama.io   | ✅    | ❌     | ❌    |
+| hanime.red      | ❌     | ✅    | ❌    |
 
 \* Requires paid membership, and is beyond the scope of this plugin.
 
 † [AV1](https://en.wikipedia.org/wiki/AV1) codec. ‡ [VP9](https://en.wikipedia.org/wiki/VP9) codec.
+
+
+| Site             | Video | Playlist | User profile / channel | Search | Subscriptions | Works without cookies                          | Works without `--impersonate chrome` | Notes |
+| ---              | :---: | :---:    | :---:                  | :---:  | :---:         | ---                                            |--------------------------------------| --- |
+| hanime1.me       | ✅    | ✅       | ✅                     | ✅     | ✅            | Public videos, search, public user pages       | Usually yes                          | cookies required for `/subscriptions`, `/user/<id>/{likes,saves,histories}` |
+| rule34video.com  | ✅    | ✅       | ✅                     | ✅     | ✅            | Public videos, search, public member tabs      | Yes                                  | cookies required for `/my/*` tabs |
+
 
 ## Examples
 
@@ -60,6 +69,13 @@ or
 
 ```
 $ yt-dlp -f - https://hentaihaven.com/video/soshite-watashi-wa-sensei-ni/episode-1
+```
+
+### Downloading a playlist / search
+
+```
+$ yt-dlp --impersonate chrome 'https://hanime1.me/search?query=Somato'
+$ yt-dlp 'https://rule34video.com/models/seejaydj/'
 ```
 
 ## FAQ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,13 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.9"
 
+[project.optional-dependencies]
+# Used by the e2e test harness under `tests/`. `curl_cffi` powers the
+# `--impersonate chrome` modes, which most cookie-fronted sites need.
+test = [
+  "pytest>=8",
+  "curl_cffi",
+]
+
 [tool.flit.module]
 name = "yt_dlp_plugins"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,225 @@
+# E2E tests
+
+These are manual end-to-end tests for the new extractors in this repo
+(currently `hanime1` and `rule34video`). They hit the live sites, so
+they need a network connection and care should be taken not to run them
+at high frequency against accounts you care about.
+
+## Running
+
+```bash
+tests/run.sh                                               # all sites, all modes
+tests/run.sh -k hanime1                                    # one site
+tests/run.sh -k 'no-cookies-no-impersonate'                # one mode
+tests/run.sh tests/sites/hanime1/test_hanime1.py::test_video
+```
+
+`run.sh` calls `python -m pytest` from the active environment. It
+verifies that `pytest` is importable and otherwise prints the install
+hint:
+
+```bash
+python -m pip install -e '.[test]'
+```
+
+That extra pulls in `pytest` and `curl_cffi`. `curl_cffi` is what
+powers the `--impersonate chrome` modes, which most cookie-fronted
+sites need.
+
+You can override the interpreter with `PYTHON=/path/to/python tests/run.sh`.
+
+## How a test is shaped
+
+Each extractor has a list of `Case` records (URL + expected id / minimum
+entries / flags). The test functions are parametrized over this list and
+across **three modes**:
+
+| Mode                          | `--cookies-from-browser` | `--impersonate chrome` |
+| ---                           | :---:                    | :---:                  |
+| `cookies-impersonate`         | yes                      | yes                    |
+| `no-cookies-impersonate`      | no                       | yes                    |
+| `minimal`                     | no                       | no                     |
+
+Skip rules:
+
+- A case marked `requires_cookies=True` runs only in `cookies-impersonate`.
+- The `minimal` mode runs only cases marked `minimal=True` (a small smoke
+  set, currently one video and one search).
+- Any mode that asks for `--impersonate` is auto-skipped if `curl_cffi`
+  failed to install.
+
+What each test asserts:
+
+| Test                          | What runs                                | Assertion |
+| ---                           | ---                                      | --- |
+| `test_video`                  | `yt-dlp --test`                          | yt-dlp exited 0, the expected id was printed, at least one file landed in the tmp output dir |
+| `test_playlist`               | `yt-dlp --simulate --flat-playlist`      | yt-dlp exited 0, at least `min_entries` ids printed |
+| `test_playlist_download_sample` | `yt-dlp --test --max-downloads 2`      | yt-dlp exited 0 or 101 (max-downloads hit), at least one file downloaded |
+| `test_owner_subpage`          | `yt-dlp --simulate --flat-playlist`      | yt-dlp exited 0; URL is built from the logged-in user id discovered from the chrome profile (see *Owner-only subpages* below) |
+
+`--test` is yt-dlp's built-in "tiny chunk" mode: lowest format, a few
+seconds of the file. It still exercises the full extractor -> format
+selection -> downloader path.
+
+## Owner-only subpages
+
+`/user/<id>/likes`, `/user/<id>/saves`, and `/user/<id>/histories` only
+render content when the visitor is the profile owner. The harness fetches
+`https://hanime1.me/` with the chrome-profile cookies, scrapes the
+logged-in account's `/user/<id>` link, and uses that id when building the
+test URLs. No personal id is hardcoded in the repo. If cookies are not
+available the `test_owner_subpage` parametrisations skip.
+
+## Cookies
+
+The `cookies-impersonate` mode passes
+`--cookies-from-browser chrome:<repo>/browser-profile`. There is no
+`browser-profile/` checked into this repo (it is gitignored and treated
+as live credentials), so you need to point that path at a real Chrome
+profile directory before any cookie-required test will run.
+
+Two options:
+
+1. **Symlink your existing Chrome profile** into the repo:
+
+   ```bash
+   # Linux
+   ln -s "$HOME/.config/google-chrome" browser-profile
+   # macOS
+   ln -s "$HOME/Library/Application Support/Google/Chrome" browser-profile
+   # Windows (cmd.exe, as administrator)
+   mklink /D browser-profile "%LOCALAPPDATA%\Google\Chrome\User Data"
+   ```
+
+2. **Use a dedicated profile.** Launch Chrome with
+   `--user-data-dir="$PWD/browser-profile"`, log into the sites you want
+   to test, close Chrome, then run the tests.
+
+Log into hanime1.me / rule34video.com in that profile at least once so
+the cookies exist on disk.
+
+**Caveats:**
+
+- Chrome / Chromium must be **closed** when you run the tests. yt-dlp
+  cannot read cookies from a profile that the browser currently has
+  open.
+- yt-dlp interprets `--cookies-from-browser chrome:PATH` as a profile
+  directory. The harness passes the absolute `browser-profile/` path.
+  If yt-dlp ever rejects the path, edit `tests/harness.py::build_cmd`
+  to point at the inner profile dir (likely `browser-profile/Default`).
+
+## Known issues
+
+- **Python 3.14 + curl_cffi.** `curl_cffi` may not have prebuilt wheels
+  for Python 3.14 yet. If `pip install -e '.[test]'` fails on
+  `curl_cffi`, the impersonate-required modes will auto-skip with a
+  clear reason. To exercise them, use Python 3.12 or 3.13 in a separate
+  venv.
+- **Cloudflare / hCaptcha.** hanime1.me sits behind Cloudflare and
+  occasionally serves an hCaptcha to anonymous traffic. The
+  `no-cookies-no-impersonate` mode is the most likely to be challenged.
+  A flake here is information about the site's bot defences, not a bug
+  in the extractor.
+
+## Case index — hanime1.me
+
+All cases live in `tests/sites/hanime1/test_hanime1.py`. The URLs below
+are the ones the tests will hit; if any of them stop being available,
+update the case list and bump `min_entries` only when the site's actual
+catalogue size justifies it.
+
+### Videos (`test_video`)
+
+| Case id                     | URL                                                          | Why |
+| ---                         | ---                                                          | --- |
+| `watch-405849`              | `https://hanime1.me/watch?v=405849`                          | Recent video, full 1080p path. Minimal smoke set. |
+| `watch-22673-old`           | `https://hanime1.me/watch?v=22673`                           | Older video with only 480p/720p. Guards against assuming 1080p exists. |
+| `watch-via-list`            | `https://hanime1.me/watch?v=155209&list=435600&sort=latest`  | URL with extra query params - the regex must still match. |
+
+### Playlists, searches, user pages (`test_playlist`)
+
+| Case id                       | URL                                                                 | Auth? | Notes |
+| ---                           | ---                                                                  | :---: | --- |
+| `search-query-Somato`         | `https://hanime1.me/search?query=Somato`                            | -     | Studio search, paginated. Minimal smoke set. |
+| `search-studio-genre`         | `https://hanime1.me/search?query=メリー・ジェーン&genre=裏番` (URL-encoded)               | -     | Matches the `_TESTS` entry in the extractor. Asserts `>=50` entries (extractor expects 120; we're conservative). |
+| `search-tag-genre`            | `https://hanime1.me/search?tags[]=接吻&genre=裏番` (URL-encoded)                      | -     | Bracket-style array tag param. |
+| `user-uploaded`               | `https://hanime1.me/user/689220/uploaded`                            | -     | Public uploader page. May be empty if the account has no uploads (`min_entries=0`). |
+| `user-playlists`              | `https://hanime1.me/user/854091/playlists`                           | -     | Public playlists tab. Account picked because it has at least one public playlist, so `min_entries=1`. Entries are `url_result`s to `Hanime1PlaylistIE`. |
+| `playlist-public`             | `https://hanime1.me/playlist?list=30618`                             | -     | Public playlist (~234 videos as of writing). `min_entries=5`. |
+| `subscriptions`               | `https://hanime1.me/subscriptions`                                  | yes   | Feed of subscribed studios; paginated; auth-only. |
+
+### Owner-only tabs (`test_owner_subpage`)
+
+| Case id                  | URL template                                | Auth? | Notes |
+| ---                      | ---                                          | :---: | --- |
+| `user-owner-likes`       | `https://hanime1.me/user/<owner>/likes`     | yes   | URL built from the logged-in user id discovered from the chrome profile. |
+| `user-owner-saves`       | `https://hanime1.me/user/<owner>/saves`     | yes   | Same. |
+| `user-owner-histories`   | `https://hanime1.me/user/<owner>/histories` | yes   | Same. |
+
+### Playlist download-sample (`test_playlist_download_sample`)
+
+Runs only on the public playlists with `min_entries > 0`. Downloads up to
+two entries with `--test` to prove the playlist -> video -> downloader
+chain works end-to-end.
+
+## Case index — rule34video.com
+
+All cases live in `tests/sites/rule34video/test_rule34video.py`. Member ids
+in test URLs are *not* the logged-in account behind the chrome profile;
+they were picked from public members observed during API exploration so
+nothing personal is checked into the repo.
+
+### Videos (`test_video`)
+
+| Case id              | URL                                                                                                | Why |
+| ---                  | ---                                                                                                | --- |
+| `watch-4321530`      | `https://rule34video.com/video/4321530/god-s-blessing-on-this-wonderful-kiss-embedded-subtitles/`  | Standard public video. Exercises the common path: flashvars parse, JSON-LD timestamp/counts, channel/categories. Minimal smoke set. |
+| `watch-3434961-4k`   | `https://rule34video.com/video/3434961/loyalty-nude-drills3d-extended/`                            | Has a 2160p variant in `video_alt_url4` with the `4k` text label. Guards against the `4k` label being parsed as height=4. |
+| `watch-bare-id`      | `https://rule34video.com/video/4321530/`                                                            | Bare-id URL (no slug). The site 404s `/video/<id>/`; the extractor must supply a placeholder slug and follow the 301 to the canonical URL. |
+
+### Lists, search, member tabs (`test_playlist`)
+
+| Case id                       | URL                                                            | Auth? | Notes |
+| ---                           | ---                                                             | :---: | --- |
+| `model-seejaydj`              | `https://rule34video.com/models/seejaydj/`                     | -     | ~24 videos for this model. Minimal smoke set. |
+| `category-dress-up-darling`   | `https://rule34video.com/categories/dress-up-darling/`         | -     | Multi-page category. `min_entries=24` to keep it a smoke check rather than a full crawl. |
+| `tag-1877`                    | `https://rule34video.com/tags/1877/`                            | -     | Numeric tag id. |
+| `search-ayaka`                | `https://rule34video.com/search/ayaka/`                         | -     | Query-based search, paginated. Smoke set. |
+| `search-model-filter`         | `https://rule34video.com/search/?model_ids=283`                | -     | Filter-only search (no query). Async pagination uses `from_videos`+`from_albums`. |
+| `playlist-124556`             | `https://rule34video.com/playlists/124556/2d-animations27/`     | -     | Public playlist owned by member 180930. |
+| `member-uploads`              | `https://rule34video.com/members/180930/videos/`                | -     | Public uploader tab. |
+| `member-favourites`           | `https://rule34video.com/members/106821/favourites/videos/`     | -     | Public favorites tab. `106821` was picked because most other public members in the area had empty/private favs. |
+| `member-playlists`            | `https://rule34video.com/members/180930/playlists/`             | -     | Public playlists tab; entries are `url_result`s to `Rule34VideoPlaylistIE`. |
+
+### /my/* tabs (`test_my_tab`)
+
+| Case id            | URL                                              | Auth? | Notes |
+| ---                | ---                                              | :---: | --- |
+| `my-favourites`    | `https://rule34video.com/my/favourites/videos/`  | yes   | The site renders content for `/my/*` only when the visitor is logged in. Anonymous and stale-session requests get redirected to `/?login`; the extractor detects this and raises a clear error. |
+| `my-videos`        | `https://rule34video.com/my/videos/`             | yes   | Same. May legitimately be empty if the account has no uploads. |
+| `my-history`       | `https://rule34video.com/my/history/`            | yes   | Same. |
+| `my-subscriptions` | `https://rule34video.com/my/subscriptions/`      | yes   | Same. |
+| `my-playlists`     | `https://rule34video.com/my/playlists/`          | yes   | Same. Entries are `url_result`s to `Rule34VideoPlaylistIE`. |
+
+The /my/* tests only run in `cookies-impersonate` mode and only pass when
+the browser-profile session is fresh. The site invalidates server-side
+sessions on a relatively short timer; if the tests start failing with the
+"requires login" error, log into rule34video.com in the chrome profile
+again to refresh the session.
+
+### Playlist download-sample (`test_playlist_download_sample`)
+
+Same as for hanime1: runs on every public list case (skipping
+`member-playlists`, whose entries are themselves playlists, and any case
+that requires cookies) and downloads up to two videos per case with
+`--test`.
+
+## Adding a new site
+
+1. Create `tests/sites/<site>/test_<site>.py`.
+2. Define `VIDEO_CASES`, `PLAYLIST_CASES` (and any other categories that
+   apply) using `harness.Case`.
+3. Reuse the `mode` and `ytdlp_runner` fixtures and the `maybe_skip`
+   helper. Use `harness.fmt_failure(result)` in assertion messages so the
+   stderr tail of a failed yt-dlp run is included in the test output.
+4. Update the root `README.md` site support table.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Pytest fixtures shared across site test modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from harness import MODES, Mode, build_cmd, discover_hanime1_owner_uid, run_ytdlp
+
+
+@pytest.fixture(params=MODES, ids=[m.id for m in MODES])
+def mode(request) -> Mode:
+    return request.param
+
+
+@pytest.fixture(scope='session')
+def hanime1_owner_uid() -> str:
+    uid = discover_hanime1_owner_uid()
+    if not uid:
+        pytest.skip('could not discover hanime1 logged-in user id from cookies')
+    return uid
+
+
+@pytest.fixture
+def ytdlp_runner(mode: Mode, tmp_path: Path):
+    """Return a callable that builds a yt-dlp command and runs it."""
+    def _run(
+        url: str,
+        *,
+        simulate: bool,
+        flat_playlist: bool = False,
+        max_downloads: int | None = None,
+        extra: tuple[str, ...] = (),
+    ):
+        output_dir = tmp_path if not simulate else None
+        cmd = build_cmd(
+            url, mode,
+            simulate=simulate,
+            flat_playlist=flat_playlist,
+            output_dir=output_dir,
+            max_downloads=max_downloads,
+            extra=extra,
+        )
+        return run_ytdlp(cmd, output_dir=output_dir)
+    return _run

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,0 +1,207 @@
+"""Shared scaffolding for the e2e extractor tests.
+
+The harness invokes yt-dlp as a subprocess so each test exercises the same
+code path a user runs from the command line. Tests are parameterised over
+three modes:
+
+  - cookies-impersonate:        --cookies-from-browser + --impersonate chrome
+  - no-cookies-impersonate:     --impersonate chrome only
+  - minimal:                    neither flag (bare yt-dlp)
+
+A test case marked ``requires_cookies`` is skipped in any mode without
+``--cookies-from-browser``. A case not marked ``minimal`` is skipped in the
+minimal mode (so the minimal mode stays a small smoke set).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BROWSER_PROFILE = REPO_ROOT / 'browser-profile'
+
+CaseKind = Literal['video', 'playlist', 'match_only']
+
+
+def discover_hanime1_owner_uid() -> str | None:
+    """Return the user id whose session lives in browser-profile/, or None.
+
+    Hits ``https://hanime1.me/`` with the chrome-profile cookies and scrapes
+    the ``/user/NNNNN`` link the site renders for the logged-in account.
+    Used by tests that read owner-only tabs (likes / saves / histories) so no
+    personal id needs to be checked into the repo.
+    """
+    if not BROWSER_PROFILE.exists():
+        return None
+    try:
+        from curl_cffi import requests as cffi_requests
+        from yt_dlp.cookies import extract_cookies_from_browser
+    except ImportError:
+        return None
+
+    import logging
+    cookie_jar = extract_cookies_from_browser(
+        'chrome', profile=str(BROWSER_PROFILE), logger=logging.getLogger('hanime1.cookies'))
+    cookies = {c.name: c.value for c in cookie_jar if 'hanime1' in c.domain}
+    if not cookies:
+        return None
+
+    resp = cffi_requests.get(
+        'https://hanime1.me/', impersonate='chrome', cookies=cookies, timeout=30)
+    m = re.search(r'href="https?://(?:www\.)?hanime1\.me/user/(\d+)"', resp.text)
+    return m.group(1) if m else None
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    url: str
+    kind: CaseKind
+    expected_id: str = ''
+    min_entries: int = 1
+    requires_cookies: bool = False
+    minimal: bool = False
+    notes: str = ''
+
+
+@dataclass(frozen=True)
+class Mode:
+    id: str
+    cookies: bool
+    impersonate: bool
+
+
+MODES: tuple[Mode, ...] = (
+    Mode('cookies-impersonate', cookies=True, impersonate=True),
+    Mode('no-cookies-impersonate', cookies=False, impersonate=True),
+    Mode('minimal', cookies=False, impersonate=False),
+)
+
+
+def can_impersonate() -> bool:
+    try:
+        import curl_cffi  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def maybe_skip(case: Case, mode: Mode) -> None:
+    """Pytest-skip when the (case, mode) pair is not exercisable."""
+    import pytest
+
+    reason = skip_reason(case, mode)
+    if reason:
+        pytest.skip(reason)
+
+
+def skip_reason(case: Case, mode: Mode) -> str:
+    if case.requires_cookies and not mode.cookies:
+        return f'case {case.id} requires --cookies-from-browser'
+    if mode.id == 'minimal' and not case.minimal:
+        return f'case {case.id} is not part of the minimal smoke set'
+    if mode.impersonate and not can_impersonate():
+        return 'curl_cffi not installed; --impersonate chrome unavailable'
+    if mode.cookies and not BROWSER_PROFILE.exists():
+        return f'no browser profile at {BROWSER_PROFILE}'
+    return ''
+
+
+def build_cmd(
+    url: str,
+    mode: Mode,
+    *,
+    simulate: bool,
+    flat_playlist: bool = False,
+    output_dir: Path | None = None,
+    max_downloads: int | None = None,
+    extra: Sequence[str] = (),
+) -> list[str]:
+    cmd: list[str] = [
+        sys.executable, '-m', 'yt_dlp',
+        '-v',
+        '--ignore-config',
+        '--no-warnings',
+        '--newline',
+    ]
+    if mode.cookies:
+        # PROFILE accepts an absolute path to a profile directory. Playwright's
+        # persistent context writes a full user-data-dir layout at the path we
+        # pass to launch_persistent_context, so the profile dir itself is the
+        # right argument here. If yt-dlp ever changes to require a profile
+        # subdir name (e.g. "Default"), this is the place to adjust.
+        cmd += ['--cookies-from-browser', f'chrome:{BROWSER_PROFILE}']
+    if mode.impersonate:
+        cmd += ['--impersonate', 'chrome']
+    if flat_playlist:
+        cmd += ['--flat-playlist']
+    if simulate:
+        cmd += ['--simulate']
+    else:
+        # --print on its own forces simulate mode, which would suppress the
+        # download. --no-simulate restores the actual --test download path.
+        cmd += ['--no-simulate', '--test']
+    if max_downloads is not None:
+        cmd += ['--max-downloads', str(max_downloads)]
+    if output_dir is not None:
+        cmd += ['-P', str(output_dir)]
+    cmd += ['--print', 'id']
+    cmd += list(extra)
+    cmd.append(url)
+    return cmd
+
+
+@dataclass
+class RunResult:
+    cmd: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    output_dir: Path | None
+
+    @property
+    def printed_ids(self) -> list[str]:
+        # `--print id` writes one id per line to stdout. yt-dlp also writes
+        # progress / verbose lines to stderr, so stdout stays parseable.
+        return [line.strip() for line in self.stdout.splitlines() if line.strip()]
+
+    @property
+    def downloaded_files(self) -> list[Path]:
+        if self.output_dir is None:
+            return []
+        return [p for p in self.output_dir.iterdir() if p.is_file() and p.stat().st_size > 0]
+
+
+def run_ytdlp(cmd: Sequence[str], *, output_dir: Path | None, timeout: int = 240) -> RunResult:
+    proc = subprocess.run(
+        list(cmd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return RunResult(
+        cmd=list(cmd),
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        output_dir=output_dir,
+    )
+
+
+def fmt_failure(result: RunResult) -> str:
+    return (
+        f'yt-dlp exited with {result.returncode}\n'
+        f'cmd: {" ".join(result.cmd)}\n'
+        f'--- stdout ---\n{result.stdout}\n'
+        f'--- stderr (tail) ---\n{"".join(result.stderr.splitlines(keepends=True)[-40:])}'
+    )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# E2E test runner. Verifies the test dependencies are importable, then
+# delegates to pytest with whatever args were passed through.
+#
+# Examples:
+#   tests/run.sh                                   # all sites, all modes
+#   tests/run.sh -k hanime1                        # just hanime1 cases
+#   tests/run.sh -k 'no-cookies-no-impersonate'    # only the minimal mode
+#   tests/run.sh tests/sites/hanime1/test_hanime1.py::test_video
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON="${PYTHON:-python3}"
+
+if ! "$PYTHON" -c 'import pytest' 2>/dev/null; then
+    echo 'error: pytest is not installed in the active Python environment.' >&2
+    echo 'Install the test extras with:' >&2
+    echo "    $PYTHON -m pip install -e '.[test]'" >&2
+    exit 2
+fi
+
+exec "$PYTHON" -m pytest "$@"

--- a/tests/sites/hanime1/test_hanime1.py
+++ b/tests/sites/hanime1/test_hanime1.py
@@ -1,0 +1,190 @@
+"""E2E tests for the hanime1.me extractor set.
+
+Run from the repo root via `tests/run.sh` (or `python -m pytest`). See
+`tests/README.md` for the list of URLs exercised here and what each case
+proves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness import Case, fmt_failure, maybe_skip
+
+
+VIDEO_CASES: list[Case] = [
+    # Public video from the active in-flight catalogue. Included in the
+    # minimal smoke set because it exercises the common code path (formats
+    # parse, channel/genre extraction, view count parse).
+    Case(
+        id='watch-405849',
+        url='https://hanime1.me/watch?v=405849',
+        kind='video',
+        expected_id='405849',
+        minimal=True,
+    ),
+    # Older video, only 480p/720p formats available - guards against assuming
+    # every video has 1080p.
+    Case(
+        id='watch-22673-old',
+        url='https://hanime1.me/watch?v=22673',
+        kind='video',
+        expected_id='22673',
+    ),
+    # `/watch?v=ID&list=...&sort=...` shape - the URL regex must still match
+    # when the watch page is reached from inside a playlist.
+    Case(
+        id='watch-via-list',
+        url='https://hanime1.me/watch?v=155209&list=435600&sort=latest',
+        kind='video',
+        expected_id='155209',
+    ),
+]
+
+
+# Owner-private tabs (likes / saves / histories). The site only renders these
+# for the logged-in account; using a hardcoded user id would either leak a
+# personal id or assert against empty pages. The fixture discovers the id from
+# the cookies at session start.
+OWNER_TABS: list[tuple[str, str]] = [
+    ('user-owner-likes', 'likes'),
+    ('user-owner-saves', 'saves'),
+    ('user-owner-histories', 'histories'),
+]
+
+
+PLAYLIST_CASES: list[Case] = [
+    # Studio search. Single-token query, paginated.
+    Case(
+        id='search-query-Somato',
+        url='https://hanime1.me/search?query=Somato',
+        kind='playlist',
+        min_entries=5,
+        minimal=True,
+    ),
+    # Studio + genre. The _TESTS entry in the extractor expects >=120 entries
+    # for this exact URL; we keep the same query but assert a lower bound so
+    # the test is not flaky if the catalogue shrinks.
+    Case(
+        id='search-studio-genre',
+        url=(
+            'https://hanime1.me/search?'
+            'query=%E3%83%A1%E3%83%AA%E3%83%BC%E3%83%BB%E3%82%B8%E3%82%A7%E3%83%BC%E3%83%B3'
+            '&genre=%E8%A3%8F%E7%95%AA'
+        ),
+        kind='playlist',
+        min_entries=50,
+    ),
+    # Tag-style search (array param).
+    Case(
+        id='search-tag-genre',
+        url=(
+            'https://hanime1.me/search?'
+            'tags%5B%5D=%E6%8E%A5%E5%90%BB'
+            '&genre=%E8%A3%8F%E7%95%AA'
+        ),
+        kind='playlist',
+        min_entries=10,
+    ),
+    # Public user profile page (uploaded tab). The uploaded list is public for
+    # every account; most regular users have no uploads so min_entries stays 0
+    # and the test just proves the page parses without errors.
+    Case(
+        id='user-uploaded',
+        url='https://hanime1.me/user/689220/uploaded',
+        kind='playlist',
+        min_entries=0,
+        notes='public uploader page; may be empty if the account has no uploads',
+    ),
+    # User's playlists tab. Public. 854091 was picked because the account has
+    # one public playlist, so min_entries=1 actually exercises entry parsing.
+    Case(
+        id='user-playlists',
+        url='https://hanime1.me/user/854091/playlists',
+        kind='playlist',
+        min_entries=1,
+        notes='lists user-owned playlists; entries are url_results to Hanime1PlaylistIE',
+    ),
+    # Public playlist with a healthy number of videos (~234 at the time of
+    # writing). Lower bound kept conservative so a few removals do not flake.
+    Case(
+        id='playlist-public',
+        url='https://hanime1.me/playlist?list=30618',
+        kind='playlist',
+        min_entries=5,
+    ),
+    # Subscriptions feed. Requires auth.
+    Case(
+        id='subscriptions',
+        url='https://hanime1.me/subscriptions',
+        kind='playlist',
+        min_entries=0,
+        requires_cookies=True,
+    ),
+]
+
+
+@pytest.mark.parametrize('case', VIDEO_CASES, ids=[c.id for c in VIDEO_CASES])
+def test_video(case: Case, mode, ytdlp_runner):
+    maybe_skip(case, mode)
+
+    result = ytdlp_runner(case.url, simulate=False)
+    assert result.returncode == 0, fmt_failure(result)
+    assert case.expected_id in result.printed_ids, (
+        f'expected id {case.expected_id!r} in printed ids, got {result.printed_ids!r}\n'
+        + fmt_failure(result)
+    )
+    files = result.downloaded_files
+    assert files, f'no file downloaded in --test mode\n{fmt_failure(result)}'
+
+
+@pytest.mark.parametrize('case', PLAYLIST_CASES, ids=[c.id for c in PLAYLIST_CASES])
+def test_playlist(case: Case, mode, ytdlp_runner):
+    maybe_skip(case, mode)
+
+    # Flat-playlist: list entries without descending into each video page.
+    result = ytdlp_runner(case.url, simulate=True, flat_playlist=True)
+    assert result.returncode == 0, fmt_failure(result)
+
+    entries = result.printed_ids
+    assert len(entries) >= case.min_entries, (
+        f'expected at least {case.min_entries} entries, got {len(entries)}: {entries[:5]}\n'
+        + fmt_failure(result)
+    )
+
+
+@pytest.mark.parametrize(
+    'case',
+    [c for c in PLAYLIST_CASES if c.min_entries > 0 and not c.requires_cookies],
+    ids=lambda c: c.id,
+)
+def test_playlist_download_sample(case: Case, mode, ytdlp_runner):
+    """Prove the playlist -> video -> download chain works end-to-end.
+
+    Restricts to one or two entries via --max-downloads so the test stays
+    fast and gentle on the site.
+    """
+    maybe_skip(case, mode)
+
+    result = ytdlp_runner(case.url, simulate=False, max_downloads=2)
+    # yt-dlp exits 101 when --max-downloads is hit. Treat that as success.
+    assert result.returncode in (0, 101), fmt_failure(result)
+
+    files = result.downloaded_files
+    assert files, f'no files downloaded from playlist\n{fmt_failure(result)}'
+
+
+@pytest.mark.parametrize('case_id,tab', OWNER_TABS, ids=[c for c, _ in OWNER_TABS])
+def test_owner_subpage(case_id, tab, mode, ytdlp_runner, hanime1_owner_uid):
+    """Owner-only tabs (likes / saves / histories).
+
+    The site renders content for these only when the visitor is the profile
+    owner, so the user id is taken from the logged-in account behind the
+    cookies rather than a hardcoded value.
+    """
+    if not mode.cookies:
+        pytest.skip(f'{case_id} requires --cookies-from-browser')
+
+    url = f'https://hanime1.me/user/{hanime1_owner_uid}/{tab}'
+    result = ytdlp_runner(url, simulate=True, flat_playlist=True)
+    assert result.returncode == 0, fmt_failure(result)

--- a/tests/sites/rule34video/test_rule34video.py
+++ b/tests/sites/rule34video/test_rule34video.py
@@ -1,0 +1,196 @@
+"""E2E tests for the rule34video.com extractor set.
+
+Run from the repo root via `tests/run.sh` (or `python -m pytest`). See
+`tests/README.md` for the list of URLs exercised here and what each case
+proves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness import Case, fmt_failure, maybe_skip
+
+
+VIDEO_CASES: list[Case] = [
+    # Standard public video. Common code path: flashvars parse, JSON-LD
+    # timestamp / counts, channel / categories. Part of the minimal smoke set.
+    Case(
+        id='watch-4321530',
+        url='https://rule34video.com/video/4321530/god-s-blessing-on-this-wonderful-kiss-embedded-subtitles/',
+        kind='video',
+        expected_id='4321530',
+        minimal=True,
+    ),
+    # Has a 2160p (4K) variant in video_alt_url4 with the `4k` text label.
+    # Guards against the "4k" label being parsed as height=4.
+    Case(
+        id='watch-3434961-4k',
+        url='https://rule34video.com/video/3434961/loyalty-nude-drills3d-extended/',
+        kind='video',
+        expected_id='3434961',
+    ),
+    # Bare-id URL (no slug). The extractor must supply a placeholder slug and
+    # follow the 301 to the canonical URL.
+    Case(
+        id='watch-bare-id',
+        url='https://rule34video.com/video/4321530/',
+        kind='video',
+        expected_id='4321530',
+    ),
+]
+
+
+PLAYLIST_CASES: list[Case] = [
+    # Public playlist owned by member 180930. Owner-curated; pagination may
+    # or may not be needed depending on current length.
+    Case(
+        id='playlist-124556',
+        url='https://rule34video.com/playlists/124556/2d-animations27/',
+        kind='playlist',
+        min_entries=5,
+    ),
+    # Model page. ~24 videos for this model (1 page). Smoke set.
+    Case(
+        id='model-seejaydj',
+        url='https://rule34video.com/models/seejaydj/',
+        kind='playlist',
+        min_entries=10,
+        minimal=True,
+    ),
+    # Category page. Heavily paginated (~100+ pages). Cap with min_entries=24
+    # so it stays a smoke test rather than a deep crawl.
+    Case(
+        id='category-dress-up-darling',
+        url='https://rule34video.com/categories/dress-up-darling/',
+        kind='playlist',
+        min_entries=24,
+    ),
+    # Tag page (numeric tag id).
+    Case(
+        id='tag-1877',
+        url='https://rule34video.com/tags/1877/',
+        kind='playlist',
+        min_entries=10,
+    ),
+    # Query-based search. ~400+ results, easily paginated. Smoke set.
+    Case(
+        id='search-ayaka',
+        url='https://rule34video.com/search/ayaka/',
+        kind='playlist',
+        min_entries=24,
+        minimal=True,
+    ),
+    # Filter-only search (model filter).
+    Case(
+        id='search-model-filter',
+        url='https://rule34video.com/search/?model_ids=283',
+        kind='playlist',
+        min_entries=24,
+    ),
+    # Public member uploads tab. Member 180930 has ~50 uploads.
+    Case(
+        id='member-uploads',
+        url='https://rule34video.com/members/180930/videos/',
+        kind='playlist',
+        min_entries=10,
+    ),
+    # Public member favourites tab. Member 106821 has ~24 public favourites
+    # as of test authoring; other ids in the area have empty/private favs.
+    Case(
+        id='member-favourites',
+        url='https://rule34video.com/members/106821/favourites/videos/',
+        kind='playlist',
+        min_entries=5,
+    ),
+    # Public member playlists tab. Entries are url_results to
+    # Rule34VideoPlaylistIE.
+    Case(
+        id='member-playlists',
+        url='https://rule34video.com/members/180930/playlists/',
+        kind='playlist',
+        min_entries=1,
+        notes='lists user-owned playlists; entries are url_results to Rule34VideoPlaylistIE',
+    ),
+]
+
+
+# /my/* tabs render content only for the logged-in account. The site
+# redirects anonymous (and stale-session) requests to `/?login` while
+# returning 200; the extractor detects the redirect and raises a clear
+# error. These tests therefore only run in cookies-impersonate mode and
+# require a fresh browser-profile login.
+MY_TABS: list[tuple[str, str]] = [
+    ('my-favourites', 'https://rule34video.com/my/favourites/videos/'),
+    ('my-videos', 'https://rule34video.com/my/videos/'),
+    ('my-history', 'https://rule34video.com/my/history/'),
+    ('my-subscriptions', 'https://rule34video.com/my/subscriptions/'),
+    ('my-playlists', 'https://rule34video.com/my/playlists/'),
+]
+
+
+@pytest.mark.parametrize('case', VIDEO_CASES, ids=[c.id for c in VIDEO_CASES])
+def test_video(case: Case, mode, ytdlp_runner):
+    maybe_skip(case, mode)
+
+    result = ytdlp_runner(case.url, simulate=False)
+    assert result.returncode == 0, fmt_failure(result)
+    assert case.expected_id in result.printed_ids, (
+        f'expected id {case.expected_id!r} in printed ids, got {result.printed_ids!r}\n'
+        + fmt_failure(result)
+    )
+    files = result.downloaded_files
+    assert files, f'no file downloaded in --test mode\n{fmt_failure(result)}'
+
+
+@pytest.mark.parametrize('case', PLAYLIST_CASES, ids=[c.id for c in PLAYLIST_CASES])
+def test_playlist(case: Case, mode, ytdlp_runner):
+    maybe_skip(case, mode)
+
+    result = ytdlp_runner(case.url, simulate=True, flat_playlist=True)
+    assert result.returncode == 0, fmt_failure(result)
+
+    entries = result.printed_ids
+    assert len(entries) >= case.min_entries, (
+        f'expected at least {case.min_entries} entries, got {len(entries)}: {entries[:5]}\n'
+        + fmt_failure(result)
+    )
+
+
+@pytest.mark.parametrize(
+    'case',
+    # Skip the member-playlists case here - entries are playlist url_results,
+    # so descending into them would download an unknown number of videos.
+    [c for c in PLAYLIST_CASES
+     if c.min_entries > 0
+     and c.id != 'member-playlists'
+     and not c.requires_cookies],
+    ids=lambda c: c.id,
+)
+def test_playlist_download_sample(case: Case, mode, ytdlp_runner):
+    """Prove the playlist -> video -> download chain works end-to-end."""
+    maybe_skip(case, mode)
+
+    result = ytdlp_runner(case.url, simulate=False, max_downloads=2)
+    # yt-dlp exits 101 when --max-downloads is hit. Treat that as success.
+    assert result.returncode in (0, 101), fmt_failure(result)
+
+    files = result.downloaded_files
+    assert files, f'no files downloaded from playlist\n{fmt_failure(result)}'
+
+
+@pytest.mark.parametrize('case_id,url', MY_TABS, ids=[c for c, _ in MY_TABS])
+def test_my_tab(case_id, url, mode, ytdlp_runner):
+    """/my/* tabs require a valid logged-in session.
+
+    The site redirects stale or missing sessions to `/?login`; the extractor
+    detects that and raises ExtractorError, which surfaces here as a non-zero
+    yt-dlp exit. If you've recently re-logged into the browser profile this
+    should pass; otherwise the test is informative about session staleness
+    rather than a bug.
+    """
+    if not mode.cookies:
+        pytest.skip(f'{case_id} requires --cookies-from-browser')
+
+    result = ytdlp_runner(url, simulate=True, flat_playlist=True)
+    assert result.returncode == 0, fmt_failure(result)

--- a/yt_dlp_plugins/extractor/hanime1.py
+++ b/yt_dlp_plugins/extractor/hanime1.py
@@ -1,0 +1,452 @@
+import itertools
+import re
+import urllib.parse
+
+from yt_dlp.extractor.common import InfoExtractor
+from yt_dlp.utils import (
+    ExtractorError,
+    clean_html,
+    extract_attributes,
+    int_or_none,
+    traverse_obj,
+    unescapeHTML,
+    unified_strdate,
+    update_url_query,
+    url_or_none,
+    urljoin,
+)
+
+
+_CJK_COUNT_UNITS = {'千': 1_000, '萬': 10_000, '万': 10_000, '億': 100_000_000}
+
+
+def _parse_cjk_count(text):
+    if not text:
+        return None
+    m = re.search(r'([\d.,]+)\s*([千萬万億])?', text)
+    if not m:
+        return None
+    try:
+        value = float(m.group(1).replace(',', ''))
+    except ValueError:
+        return None
+    return int(value * _CJK_COUNT_UNITS.get(m.group(2), 1))
+
+
+class Hanime1IE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/watch\?(?:[^#]*&)?v=(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://hanime1.me/watch?v=405849',
+        'info_dict': {
+            'id': '405849',
+            'ext': 'mp4',
+            'title': 'ボクの理想の異世界生活 第4話 [中文字幕]',
+            'description': 'md5:bf5621c5550daf3796358a5e9b82edfc',
+            'duration': 991,
+            'age_limit': 18,
+            'channel': 'メリー・ジェーン',
+            'channel_url': 'https://hanime1.me/search?query=メリー・ジェーン&genre=裏番',
+            'uploader': 'メリー・ジェーン',
+            'thumbnail': r're:^https?://.+\.jpg',
+            'upload_date': '20260417',
+            'view_count': int,
+            'like_count': int,
+            'dislike_count': int,
+            'comment_count': int,
+            'tags': list,
+            'categories': ['裏番'],
+        },
+        'params': {'skip_download': True},
+    }, {
+        # Older entry by the same studio, only 720p / 480p available
+        'url': 'https://hanime1.me/watch?v=22673',
+        'info_dict': {
+            'id': '22673',
+            'ext': 'mp4',
+            'title': 'ショッキングピンク！ 第2話 長坂の戦い  [中文字幕]',
+            'channel': 'メリー・ジェーン',
+            'categories': ['裏番'],
+            'age_limit': 18,
+            'duration': 987,
+            'upload_date': '20110805',
+        },
+        'params': {'skip_download': True},
+    }, {
+        'url': 'https://hanime1.me/watch?v=99690',
+        'only_matching': True,
+    }, {
+        # /watch URL with extra query params (?v=ID&list=...&sort=...)
+        'url': 'https://hanime1.me/watch?v=155209&list=435600&sort=latest',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        formats = []
+        for tag in re.findall(r'<source\b[^>]*>', webpage):
+            attrs = extract_attributes(tag)
+            src = url_or_none(attrs.get('src'))
+            if not src:
+                continue
+            height = int_or_none(attrs.get('size'))
+            formats.append({
+                'url': src,
+                'ext': 'mp4',
+                'format_id': f'{height}p' if height else None,
+                'height': height,
+            })
+        if not formats:
+            raise ExtractorError('No video sources found', expected=True)
+
+        title = self._og_search_title(webpage, default=None)
+        if title:
+            title = re.sub(r'\s*[-|]\s*Hanime1(?:\.me)?\s*$', '', title)
+        else:
+            title = self._html_extract_title(webpage, default=video_id)
+
+        artist_match = re.search(
+            r'<a[^>]*id="video-artist-name"[^>]*href="([^"]+)"[^>]*>\s*([^<]+?)\s*</a>',
+            webpage)
+        channel = artist_match.group(2).strip() if artist_match else None
+        channel_url = urljoin(url, unescapeHTML(artist_match.group(1))) if artist_match else None
+
+        # The video's genre is the genre param on the artist link, not the
+        # genre nav menu at the top of the page (that lists every site genre).
+        genre = None
+        if channel_url:
+            genre = traverse_obj(
+                urllib.parse.parse_qs(urllib.parse.urlsplit(channel_url).query),
+                ('genre', 0))
+
+        # The view count and upload date are colocated in a single span, e.g.:
+        #   觀看次數：183.5萬次  2026-04-17
+        # 萬 means 10000 in Chinese - parse_count only handles K/M.
+        stats_match = re.search(
+            r'觀看次數[：:]\s*([\d.,]+\s*[千萬万億]?)次(?:\s|&nbsp;)*(\d{4}-\d{1,2}-\d{1,2})',
+            webpage)
+        view_count = _parse_cjk_count(stats_match.group(1)) if stats_match else None
+        upload_date = unified_strdate(stats_match.group(2)) if stats_match else None
+
+        # Hidden form inputs carry raw like/dislike counts, but only render
+        # when the visitor is logged in. For logged-out requests fall back to
+        # the visible button: `thumb_up</i>100%&nbsp;&nbsp;<span>(16769)</span>`
+        # where the parenthesized number is the like count and the percent is
+        # likes / (likes + dislikes).
+        like_count = int_or_none(self._search_regex(
+            r'name="likes-count"[^>]*value="(\d+)"', webpage, 'like count', default=None))
+        dislike_count = int_or_none(self._search_regex(
+            r'name="unlikes-count"[^>]*value="(\d+)"', webpage, 'dislike count', default=None))
+        if like_count is None:
+            like_visible = re.search(
+                r'thumb_up\s*</i>\s*(\d+)\s*%\s*(?:&nbsp;|\s)*<span>\s*\(\s*(\d+)\s*\)',
+                webpage)
+            if like_visible:
+                like_percent = int(like_visible.group(1))
+                like_count = int(like_visible.group(2))
+                if dislike_count is None and like_percent > 0:
+                    # L + D = L * 100 / percent
+                    dislike_count = max(0, round(like_count * 100 / like_percent) - like_count)
+        comment_count = int_or_none(self._search_regex(
+            r'id="tab-comments-count"[^>]*>\s*(\d+)', webpage, 'comment count', default=None))
+
+        # Prefer the on-page description block (the OG description truncates).
+        description = clean_html(self._search_regex(
+            r'<div class="video-caption-text[^"]*"[^>]*>([\s\S]*?)</div>',
+            webpage, 'description', default=None))
+        if not description:
+            description = self._og_search_description(webpage, default=None)
+
+        keywords = self._html_search_meta('keywords', webpage, default='') or ''
+        tags = [t.strip() for t in keywords.split(',') if t.strip()]
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'thumbnail': self._og_search_thumbnail(webpage, default=None),
+            'duration': int_or_none(self._og_search_property(
+                'video:duration', webpage, default=None)),
+            'formats': formats,
+            'age_limit': 18,
+            'channel': channel,
+            'channel_url': channel_url,
+            'uploader': channel,
+            'view_count': view_count,
+            'like_count': like_count,
+            'dislike_count': dislike_count,
+            'comment_count': comment_count,
+            'upload_date': upload_date,
+            'tags': tags,
+            'categories': [genre] if genre else None,
+        }
+
+
+def _parse_username(webpage, fallback):
+    # User pages all share the same H1 with the display name. Fall back to
+    # the page <title>, which begins with the page heading (likes / saves /
+    # playlists / "my list" / uploaded) - not the username, but better than
+    # the bare ID.
+    return clean_html(re.sub(
+        r'<[^>]+>', '',
+        next(iter(re.findall(r'<h1[^>]*>([^<]+)</h1>', webpage)), ''),
+    )) or fallback
+
+
+def _extract_video_ids(webpage):
+    # Cards repeat IDs in thumbnail, title, and overlay links; dedupe in
+    # document order so the playlist comes back in the order it was rendered.
+    return list(dict.fromkeys(re.findall(r'/watch\?v=(\d+)', webpage)))
+
+
+def _video_url_result(extractor, video_id):
+    return extractor.url_result(
+        f'https://hanime1.me/watch?v={video_id}', Hanime1IE, video_id)
+
+
+class _Hanime1ListBaseIE(InfoExtractor):
+    """Shared bits for list/playlist-style extractors.
+
+    Hanime1 has two list-page styles:
+
+    - Paginated (search, subscriptions): the page embeds `urlParams.get('page')
+      < TOTAL - 1` in its inline script.
+    - Single-page (playlists, user subpages): no pagination JS, every entry is
+      rendered up front.
+
+    Subclasses set `_PAGINATED` accordingly. The paginated path mirrors the
+    behavior of the original Hanime1SearchIE.
+    """
+    _PAGINATED = False
+
+    def _paginated_entries(self, base_url, playlist_id):
+        seen = set()
+        for page_num in itertools.count(1):
+            page_url = update_url_query(base_url, {'page': page_num})
+            webpage = self._download_webpage(
+                page_url, playlist_id, note=f'Downloading page {page_num}',
+                fatal=page_num == 1)
+            if not webpage:
+                return
+
+            new_ids = [vid for vid in _extract_video_ids(webpage) if vid not in seen]
+            for vid in new_ids:
+                seen.add(vid)
+                yield _video_url_result(self, vid)
+
+            total = int_or_none(self._search_regex(
+                r"urlParams\.get\(['\"]page['\"]\)\s*<\s*(\d+)\s*-\s*1",
+                webpage, 'total pages', default=None))
+            if total is not None:
+                if page_num >= total:
+                    return
+            elif not new_ids:
+                return
+
+    def _single_page_entries(self, webpage):
+        for vid in _extract_video_ids(webpage):
+            yield _video_url_result(self, vid)
+
+
+class Hanime1PlaylistIE(_Hanime1ListBaseIE):
+    IE_NAME = 'hanime1:playlist'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/playlist\?(?:[^#]*&)?list=(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://hanime1.me/playlist?list=30618',
+        'only_matching': True,
+    }, {
+        'url': 'https://hanime1.me/playlist?list=30618&sort=latest',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        webpage = self._download_webpage(url, playlist_id)
+
+        title = clean_html(self._search_regex(
+            r'<h1[^>]*class="[^"]*playlist-title[^"]*"[^>]*>([^<]+)</h1>',
+            webpage, 'playlist title', default=None)) or playlist_id
+
+        owner_match = re.search(
+            r'class="playlist-author-info"[\s\S]*?href="([^"]*?/user/(\d+))"[^>]*>\s*([^<]+?)\s*</a>',
+            webpage)
+        uploader = owner_match.group(3).strip() if owner_match else None
+        uploader_id = owner_match.group(2) if owner_match else None
+        uploader_url = urljoin(url, owner_match.group(1)) if owner_match else None
+
+        playlist_count = int_or_none(self._search_regex(
+            r'id="sidebar-video-count"[^>]*>\s*(\d+)', webpage, 'video count',
+            default=None))
+
+        return self.playlist_result(
+            self._single_page_entries(webpage), playlist_id, title,
+            uploader=uploader, uploader_id=uploader_id, uploader_url=uploader_url,
+            playlist_count=playlist_count)
+
+
+class _Hanime1UserListBaseIE(_Hanime1ListBaseIE):
+    """A user subpage with a single inline list of videos (no pagination).
+
+    Concrete subclasses set `_TAB` (URL suffix, '' for the bare profile),
+    `_TAB_LABEL` (human label appended to the playlist title), and `IE_NAME`.
+    """
+    _TAB = ''
+    _TAB_LABEL = ''
+
+    def _real_extract(self, url):
+        user_id = self._match_id(url)
+        page_url = f'https://hanime1.me/user/{user_id}'
+        if self._TAB:
+            page_url += f'/{self._TAB}'
+        webpage = self._download_webpage(page_url, user_id)
+
+        username = _parse_username(webpage, user_id)
+        playlist_id = f'{user_id}-{self._TAB}' if self._TAB else user_id
+        title = f'{username} - {self._TAB_LABEL}' if self._TAB_LABEL else username
+
+        return self.playlist_result(
+            self._single_page_entries(webpage), playlist_id, title,
+            uploader=username, uploader_id=user_id, uploader_url=page_url)
+
+
+class Hanime1UserIE(_Hanime1UserListBaseIE):
+    """Videos uploaded by a user - the closest hanime1 has to a "model" channel."""
+    IE_NAME = 'hanime1:user'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)(?:/uploaded)?/?(?:\?|$)'
+    _TAB = 'uploaded'
+    _TAB_LABEL = 'Uploaded'
+    _TESTS = [{
+        'url': 'https://hanime1.me/user/689220/uploaded',
+        'only_matching': True,
+    }, {
+        'url': 'https://hanime1.me/user/689220',
+        'only_matching': True,
+    }]
+
+
+class Hanime1UserLikesIE(_Hanime1UserListBaseIE):
+    IE_NAME = 'hanime1:user:likes'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)/likes/?(?:\?|$)'
+    _TAB = 'likes'
+    _TAB_LABEL = 'Likes'
+    _TESTS = [{
+        'url': 'https://hanime1.me/user/979597/likes',
+        'only_matching': True,
+    }]
+
+
+class Hanime1UserSavesIE(_Hanime1UserListBaseIE):
+    IE_NAME = 'hanime1:user:saves'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)/saves/?(?:\?|$)'
+    _TAB = 'saves'
+    _TAB_LABEL = 'Saves'
+    _TESTS = [{
+        'url': 'https://hanime1.me/user/1262549/saves',
+        'only_matching': True,
+    }]
+
+
+class Hanime1UserHistoryIE(_Hanime1UserListBaseIE):
+    IE_NAME = 'hanime1:user:history'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)/histories/?(?:\?|$)'
+    _TAB = 'histories'
+    _TAB_LABEL = 'History'
+    _TESTS = [{
+        'url': 'https://hanime1.me/user/666925/histories',
+        'only_matching': True,
+    }]
+
+
+class Hanime1UserPlaylistsIE(InfoExtractor):
+    IE_NAME = 'hanime1:user:playlists'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)/playlists/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://hanime1.me/user/854091/playlists',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        user_id = self._match_id(url)
+        webpage = self._download_webpage(url, user_id)
+        username = _parse_username(webpage, user_id)
+
+        def entries():
+            seen = set()
+            for m in re.finditer(r'/playlist\?list=(\d+)', webpage):
+                pl_id = m.group(1)
+                if pl_id in seen:
+                    continue
+                seen.add(pl_id)
+                yield self.url_result(
+                    f'https://hanime1.me/playlist?list={pl_id}',
+                    Hanime1PlaylistIE, pl_id)
+
+        return self.playlist_result(
+            entries(), f'{user_id}-playlists', f'{username} - Playlists',
+            uploader=username, uploader_id=user_id)
+
+
+class Hanime1SubscriptionsIE(_Hanime1ListBaseIE):
+    IE_NAME = 'hanime1:subscriptions'
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/subscriptions(?:\?[^#]*)?/?$'
+    _PAGINATED = True
+    _TESTS = [{
+        'url': 'https://hanime1.me/subscriptions',
+        'only_matching': True,
+    }, {
+        'url': 'https://hanime1.me/subscriptions?genre=Cosplay',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        playlist_id = 'subscriptions'
+        return self.playlist_result(
+            self._paginated_entries(url, playlist_id), playlist_id, 'Subscriptions')
+
+
+class Hanime1SearchIE(_Hanime1ListBaseIE):
+    IE_NAME = 'hanime1:search'
+    # Match /search with at least one query parameter. This catches studio
+    # (?query=...), tag (?tags[]=...), and genre (?genre=...) URLs.
+    _VALID_URL = r'https?://(?:www\.)?hanime1\.me/search\?(?P<query>[^#]+)'
+    _PAGINATED = True
+    _TESTS = [{
+        'url': 'https://hanime1.me/search?query=%E3%83%A1%E3%83%AA%E3%83%BC%E3%83%BB%E3%82%B8%E3%82%A7%E3%83%BC%E3%83%B3&genre=%E8%A3%8F%E7%95%AA',
+        'info_dict': {
+            'id': 'query=メリー・ジェーン&genre=裏番',
+            'title': 'メリー・ジェーン - 裏番',
+        },
+        'playlist_mincount': 120,
+    }, {
+        # Studio query (no genre)
+        'url': 'https://hanime1.me/search?query=Somato',
+        'only_matching': True,
+    }, {
+        # Tag (note the bracket-style array param)
+        'url': 'https://hanime1.me/search?tags%5B%5D=%E6%8E%A5%E5%90%BB&genre=%E8%A3%8F%E7%95%AA',
+        'only_matching': True,
+    }, {
+        # Genre only
+        'url': 'https://hanime1.me/search?genre=%E8%A3%8F%E7%95%AA',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        query = self._match_valid_url(url).group('query')
+        playlist_id = urllib.parse.unquote(query)
+        title = self._playlist_title(playlist_id) or playlist_id
+        return self.playlist_result(
+            self._paginated_entries(url, playlist_id), playlist_id, title)
+
+    @staticmethod
+    def _playlist_title(query_str):
+        parsed = urllib.parse.parse_qs(query_str)
+        parts = traverse_obj(parsed, ('query', 0)) or traverse_obj(parsed, ('tags[]',))
+        if isinstance(parts, str):
+            parts = [parts]
+        parts = list(parts or [])
+        genre = traverse_obj(parsed, ('genre', 0))
+        if genre:
+            parts.append(genre)
+        return ' - '.join(parts) if parts else None

--- a/yt_dlp_plugins/extractor/hanime1.py
+++ b/yt_dlp_plugins/extractor/hanime1.py
@@ -8,29 +8,12 @@ from yt_dlp.utils import (
     clean_html,
     extract_attributes,
     int_or_none,
+    orderedSet,
     traverse_obj,
-    unescapeHTML,
     unified_strdate,
-    update_url_query,
     url_or_none,
     urljoin,
 )
-
-
-_CJK_COUNT_UNITS = {'千': 1_000, '萬': 10_000, '万': 10_000, '億': 100_000_000}
-
-
-def _parse_cjk_count(text):
-    if not text:
-        return None
-    m = re.search(r'([\d.,]+)\s*([千萬万億])?', text)
-    if not m:
-        return None
-    try:
-        value = float(m.group(1).replace(',', ''))
-    except ValueError:
-        return None
-    return int(value * _CJK_COUNT_UNITS.get(m.group(2), 1))
 
 
 class Hanime1IE(InfoExtractor):
@@ -80,6 +63,21 @@ class Hanime1IE(InfoExtractor):
         'only_matching': True,
     }]
 
+    _COUNT_UNITS = {'千': 1_000, '萬': 10_000, '万': 10_000, '億': 100_000_000}
+
+    @classmethod
+    def _parse_cjk_count(cls, text):
+        if not text:
+            return None
+        m = re.search(r'([\d.,]+)\s*([千萬万億])?', text)
+        if not m:
+            return None
+        try:
+            value = float(m.group(1).replace(',', ''))
+        except ValueError:
+            return None
+        return int(value * cls._COUNT_UNITS.get(m.group(2), 1))
+
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
@@ -106,11 +104,10 @@ class Hanime1IE(InfoExtractor):
         else:
             title = self._html_extract_title(webpage, default=video_id)
 
-        artist_match = re.search(
+        channel_href, channel = self._html_search_regex(
             r'<a[^>]*id="video-artist-name"[^>]*href="([^"]+)"[^>]*>\s*([^<]+?)\s*</a>',
-            webpage)
-        channel = artist_match.group(2).strip() if artist_match else None
-        channel_url = urljoin(url, unescapeHTML(artist_match.group(1))) if artist_match else None
+            webpage, 'channel', group=(1, 2), default=(None, None))
+        channel_url = urljoin(url, channel_href) if channel_href else None
 
         # The video's genre is the genre param on the artist link, not the
         # genre nav menu at the top of the page (that lists every site genre).
@@ -126,7 +123,7 @@ class Hanime1IE(InfoExtractor):
         stats_match = re.search(
             r'觀看次數[：:]\s*([\d.,]+\s*[千萬万億]?)次(?:\s|&nbsp;)*(\d{4}-\d{1,2}-\d{1,2})',
             webpage)
-        view_count = _parse_cjk_count(stats_match.group(1)) if stats_match else None
+        view_count = self._parse_cjk_count(stats_match.group(1)) if stats_match else None
         upload_date = unified_strdate(stats_match.group(2)) if stats_match else None
 
         # Hidden form inputs carry raw like/dislike counts, but only render
@@ -183,28 +180,6 @@ class Hanime1IE(InfoExtractor):
         }
 
 
-def _parse_username(webpage, fallback):
-    # User pages all share the same H1 with the display name. Fall back to
-    # the page <title>, which begins with the page heading (likes / saves /
-    # playlists / "my list" / uploaded) - not the username, but better than
-    # the bare ID.
-    return clean_html(re.sub(
-        r'<[^>]+>', '',
-        next(iter(re.findall(r'<h1[^>]*>([^<]+)</h1>', webpage)), ''),
-    )) or fallback
-
-
-def _extract_video_ids(webpage):
-    # Cards repeat IDs in thumbnail, title, and overlay links; dedupe in
-    # document order so the playlist comes back in the order it was rendered.
-    return list(dict.fromkeys(re.findall(r'/watch\?v=(\d+)', webpage)))
-
-
-def _video_url_result(extractor, video_id):
-    return extractor.url_result(
-        f'https://hanime1.me/watch?v={video_id}', Hanime1IE, video_id)
-
-
 class _Hanime1ListBaseIE(InfoExtractor):
     """Shared bits for list/playlist-style extractors.
 
@@ -220,20 +195,32 @@ class _Hanime1ListBaseIE(InfoExtractor):
     """
     _PAGINATED = False
 
+    @staticmethod
+    def _extract_video_ids(webpage):
+        # Cards repeat IDs in thumbnail, title, and overlay links; dedupe in
+        # document order so the playlist comes back in the order it was rendered.
+        return orderedSet(re.findall(r'/watch\?v=(\d+)', webpage))
+
+    def _video_url_result(self, video_id):
+        return self.url_result(
+            f'https://hanime1.me/watch?v={video_id}', Hanime1IE, video_id)
+
     def _paginated_entries(self, base_url, playlist_id):
         seen = set()
         for page_num in itertools.count(1):
-            page_url = update_url_query(base_url, {'page': page_num})
             webpage = self._download_webpage(
-                page_url, playlist_id, note=f'Downloading page {page_num}',
-                fatal=page_num == 1)
+                base_url, playlist_id, note=f'Downloading page {page_num}',
+                fatal=page_num == 1, query={'page': page_num})
             if not webpage:
                 return
 
-            new_ids = [vid for vid in _extract_video_ids(webpage) if vid not in seen]
-            for vid in new_ids:
+            found_new = False
+            for vid in self._extract_video_ids(webpage):
+                if vid in seen:
+                    continue
                 seen.add(vid)
-                yield _video_url_result(self, vid)
+                found_new = True
+                yield self._video_url_result(vid)
 
             total = int_or_none(self._search_regex(
                 r"urlParams\.get\(['\"]page['\"]\)\s*<\s*(\d+)\s*-\s*1",
@@ -241,12 +228,18 @@ class _Hanime1ListBaseIE(InfoExtractor):
             if total is not None:
                 if page_num >= total:
                     return
-            elif not new_ids:
+            elif not found_new:
                 return
 
     def _single_page_entries(self, webpage):
-        for vid in _extract_video_ids(webpage):
-            yield _video_url_result(self, vid)
+        for vid in self._extract_video_ids(webpage):
+            yield self._video_url_result(vid)
+
+    def _parse_username(self, webpage, fallback):
+        # User pages share an H1 with the display name; fall back to the bare
+        # ID when it's absent.
+        return self._html_search_regex(
+            r'<h1[^>]*>([^<]+)</h1>', webpage, 'username', default=None) or fallback
 
 
 class Hanime1PlaylistIE(_Hanime1ListBaseIE):
@@ -264,9 +257,9 @@ class Hanime1PlaylistIE(_Hanime1ListBaseIE):
         playlist_id = self._match_id(url)
         webpage = self._download_webpage(url, playlist_id)
 
-        title = clean_html(self._search_regex(
+        title = self._html_search_regex(
             r'<h1[^>]*class="[^"]*playlist-title[^"]*"[^>]*>([^<]+)</h1>',
-            webpage, 'playlist title', default=None)) or playlist_id
+            webpage, 'playlist title', default=None) or playlist_id
 
         owner_match = re.search(
             r'class="playlist-author-info"[\s\S]*?href="([^"]*?/user/(\d+))"[^>]*>\s*([^<]+?)\s*</a>',
@@ -301,7 +294,7 @@ class _Hanime1UserListBaseIE(_Hanime1ListBaseIE):
             page_url += f'/{self._TAB}'
         webpage = self._download_webpage(page_url, user_id)
 
-        username = _parse_username(webpage, user_id)
+        username = self._parse_username(webpage, user_id)
         playlist_id = f'{user_id}-{self._TAB}' if self._TAB else user_id
         title = f'{username} - {self._TAB_LABEL}' if self._TAB_LABEL else username
 
@@ -358,7 +351,7 @@ class Hanime1UserHistoryIE(_Hanime1UserListBaseIE):
     }]
 
 
-class Hanime1UserPlaylistsIE(InfoExtractor):
+class Hanime1UserPlaylistsIE(_Hanime1ListBaseIE):
     IE_NAME = 'hanime1:user:playlists'
     _VALID_URL = r'https?://(?:www\.)?hanime1\.me/user/(?P<id>\d+)/playlists/?(?:\?|$)'
     _TESTS = [{
@@ -369,7 +362,7 @@ class Hanime1UserPlaylistsIE(InfoExtractor):
     def _real_extract(self, url):
         user_id = self._match_id(url)
         webpage = self._download_webpage(url, user_id)
-        username = _parse_username(webpage, user_id)
+        username = self._parse_username(webpage, user_id)
 
         def entries():
             seen = set()

--- a/yt_dlp_plugins/extractor/rule34video.py
+++ b/yt_dlp_plugins/extractor/rule34video.py
@@ -1,0 +1,519 @@
+import itertools
+import re
+import urllib.parse
+
+from yt_dlp.extractor.common import InfoExtractor
+from yt_dlp.utils import (
+    ExtractorError,
+    clean_html,
+    int_or_none,
+    traverse_obj,
+    unescapeHTML,
+    update_url_query,
+    url_or_none,
+)
+
+
+_BASE = 'https://rule34video.com'
+
+
+def _split_csv(s):
+    return [p.strip() for p in (s or '').split(',') if p.strip()]
+
+
+def _extract_video_ids(webpage):
+    # Cards repeat each id (overlay link + thumbnail link), so dedupe while
+    # keeping document order to preserve the listing order.
+    return list(dict.fromkeys(re.findall(r'/video/(\d+)/', webpage)))
+
+
+def _extract_playlist_ids(webpage):
+    return list(dict.fromkeys(re.findall(r'/playlists/(\d+)/', webpage)))
+
+
+def _video_url_result(extractor, video_id):
+    return extractor.url_result(
+        f'{_BASE}/video/{video_id}/', Rule34VideoIE, video_id)
+
+
+def _playlist_url_result(extractor, playlist_id):
+    return extractor.url_result(
+        f'{_BASE}/playlists/{playlist_id}/', Rule34VideoPlaylistIE, playlist_id)
+
+
+class Rule34VideoIE(InfoExtractor):
+    IE_NAME = 'rule34video'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/video/(?P<id>\d+)(?:/(?P<slug>[^/?#]*))?/?'
+    _TESTS = [{
+        'url': 'https://rule34video.com/video/4321530/god-s-blessing-on-this-wonderful-kiss-embedded-subtitles/',
+        'info_dict': {
+            'id': '4321530',
+            'ext': 'mp4',
+            'title': "God's Blessing on This Wonderful Kiss! (Embedded Subtitles)",
+            'duration': 373,
+            'timestamp': 1775433600,
+            'upload_date': '20260406',
+            'age_limit': 18,
+            'thumbnail': r're:^https?://.+\.jpg',
+            'view_count': int,
+            'like_count': int,
+            'channel': 'Shiina Ecchi',
+            'uploader': 'Shiina Ecchi',
+            'categories': ['kono subarashii sekai ni shukufuku wo!', '2D'],
+            'tags': list,
+        },
+        'params': {'skip_download': True},
+    }, {
+        # Has a 2160p (4K) variant via video_alt_url4
+        'url': 'https://rule34video.com/video/3434961/loyalty-nude-drills3d-extended/',
+        'info_dict': {
+            'id': '3434961',
+            'ext': 'mp4',
+            'title': 'Loyalty [Nude][Drills3D][Extended]',
+            'age_limit': 18,
+            'channel': 'Drills3D',
+            'categories': ['3D', 'The Last of Us 2'],
+        },
+        'params': {'skip_download': True},
+    }, {
+        'url': 'https://rule34video.com/video/4321530/',
+        'only_matching': True,
+    }]
+
+    # `<key>: 'value'` literal scraped from the flashvars JS block on the
+    # video page. Values are single-quoted JS strings, so backslash escapes
+    # (e.g. \') must be unwrapped before use.
+    _FLASHVAR_RE = re.compile(r"\b{key}\s*:\s*'((?:\\.|[^\\'])*)'")
+
+    @classmethod
+    def _flashvar(cls, key, webpage):
+        m = cls._FLASHVAR_RE.pattern.format(key=re.escape(key))
+        match = re.search(m, webpage)
+        if not match:
+            return None
+        return re.sub(r"\\(['\\])", r'\1', match.group(1))
+
+    def _real_extract(self, url):
+        m = self._match_valid_url(url)
+        video_id = m.group('id')
+        # The site rejects /video/<id>/ with 404 and 301-redirects any non-empty
+        # slug to the canonical /video/<id>/<canonical-slug>/. Pass through the
+        # user's slug when present so we hit the canonical URL on the first
+        # request; otherwise use a placeholder and let the redirect resolve it.
+        webpage = self._download_webpage(
+            f'{_BASE}/video/{video_id}/{m.group("slug") or "x"}/', video_id)
+
+        # JSON-LD VideoObject is the friendliest metadata source when present,
+        # but pages re-rendered through the ad-refresh path drop it, so every
+        # field below is also recoverable from the flashvars block or markup.
+        ld = self._search_json_ld(webpage, video_id, default={})
+
+        formats = []
+        # video_url is the bare-360p stream; video_alt_url{,2,3,4} carry the
+        # alternates with `_text` labels like 360p/480p/720p/1080p/4k.
+        for key, height_hint in [
+            ('video_url', None),
+            ('video_alt_url', None),
+            ('video_alt_url2', None),
+            ('video_alt_url3', None),
+            ('video_alt_url4', None),
+        ]:
+            src = url_or_none(self._flashvar(key, webpage))
+            if not src:
+                continue
+            label = (self._flashvar(f'{key}_text', webpage) or '').lower()
+            # `_text` is e.g. '360p', '1080p', '4k'. The bare video_url has no
+            # _text - read its height from the filename suffix. 4k carries no
+            # numeric height in its label, so handle it explicitly.
+            if label == '4k':
+                height = 2160
+            else:
+                m = re.match(r'(\d+)p?$', label)
+                height = int_or_none(m.group(1)) if m else None
+            if not height:
+                fn_match = re.search(r'_(\d+)p?\.mp4', src)
+                if fn_match:
+                    height = int_or_none(fn_match.group(1))
+            formats.append({
+                'url': src,
+                'ext': 'mp4',
+                'format_id': f'{height}p' if height else label or None,
+                'height': height,
+            })
+        if not formats:
+            raise ExtractorError('No video sources found', expected=True)
+
+        title = (
+            traverse_obj(ld, 'title')
+            or self._flashvar('video_title', webpage)
+            or self._html_extract_title(webpage, default=video_id))
+
+        thumbnail = (
+            url_or_none(traverse_obj(ld, ('thumbnails', 0, 'url')))
+            or url_or_none(self._flashvar('preview_url', webpage)))
+
+        duration = int_or_none(traverse_obj(ld, 'duration'))
+
+        # _search_json_ld normalises VideoObject.uploadDate to a unix timestamp.
+        timestamp = traverse_obj(ld, 'timestamp', expected_type=int_or_none)
+
+        view_count = traverse_obj(ld, 'view_count', expected_type=int_or_none)
+        like_count = traverse_obj(ld, 'like_count', expected_type=int_or_none)
+
+        # flashvars give us comma-separated strings; the first model is the
+        # uploading studio/artist, treat it as the channel.
+        categories = _split_csv(self._flashvar('video_categories', webpage))
+        tags = _split_csv(self._flashvar('video_tags', webpage))
+        models = _split_csv(self._flashvar('video_models', webpage))
+        channel = models[0] if models else None
+
+        description = clean_html(traverse_obj(ld, 'description')) or None
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'thumbnail': thumbnail,
+            'duration': duration,
+            'timestamp': timestamp,
+            'view_count': view_count,
+            'like_count': like_count,
+            'age_limit': 18,
+            'channel': channel,
+            'uploader': channel,
+            'formats': formats,
+            'categories': categories or None,
+            'tags': tags or None,
+        }
+
+
+class _Rule34VideoListBaseIE(InfoExtractor):
+    """Pagination helpers for the KVS-style listing pages on rule34video.
+
+    Every list page (categories, models, tags, search, member tabs, /my/*)
+    renders the first batch of cards inline and exposes a
+    `<div id="<block_id>_pagination">` block when more pages exist. The same
+    URL with `?mode=async&function=get_block&block_id=<block_id>&from=NN`
+    returns the HTML of page NN as a partial fragment. Search uses
+    `from_videos` + `from_albums` instead of `from`.
+    """
+
+    def _paginate(
+        self, base_url, playlist_id, *, ids_from=_extract_video_ids,
+        async_pagination_keys=('from',), first_page=None,
+    ):
+        # ``first_page`` lets the caller hand in a webpage they already had
+        # to fetch (e.g. to extract a title) so we don't request page 1 twice.
+        webpage = first_page if first_page is not None else self._download_webpage(
+            base_url, playlist_id)
+
+        seen = set()
+        for vid in ids_from(webpage):
+            if vid not in seen:
+                seen.add(vid)
+                yield vid
+
+        block_id = self._search_regex(
+            r'id="([a-z_]+)_pagination"', webpage, 'block id', default=None)
+        if not block_id:
+            return
+        # The pagination block exposes one anchor per visible page with a
+        # `from*:NN` data-parameter. The parameter name varies by page type
+        # (`from`, `from_videos`, `from_videos+from_albums`), so match any
+        # name beginning with `from`. Take the max as the last page.
+        page_numbers = [
+            int(n) for n in re.findall(
+                r'data-parameters="(?:[^"]*;)?from[a-z_+]*:0*(\d+)"', webpage)
+        ]
+        total_pages = max(page_numbers) if page_numbers else 0
+        if total_pages <= 1:
+            return
+
+        for page_num in itertools.count(2):
+            if page_num > total_pages:
+                return
+            query = {
+                'mode': 'async',
+                'function': 'get_block',
+                'block_id': block_id,
+                'sort_by': 'post_date',
+            }
+            for k in async_pagination_keys:
+                query[k] = f'{page_num:02d}'
+            page_url = update_url_query(base_url, query)
+            chunk = self._download_webpage(
+                page_url, playlist_id, note=f'Downloading page {page_num}',
+                fatal=False)
+            if not chunk:
+                return
+            new_ids = [vid for vid in ids_from(chunk) if vid not in seen]
+            if not new_ids:
+                return
+            for vid in new_ids:
+                seen.add(vid)
+                yield vid
+
+    def _video_entries(self, base_url, playlist_id, **kwargs):
+        for vid in self._paginate(base_url, playlist_id, **kwargs):
+            yield _video_url_result(self, vid)
+
+    def _playlist_entries(self, base_url, playlist_id, **kwargs):
+        for pid in self._paginate(
+            base_url, playlist_id,
+            ids_from=_extract_playlist_ids, **kwargs,
+        ):
+            yield _playlist_url_result(self, pid)
+
+
+def _title_text(webpage, fallback):
+    title = clean_html(unescapeHTML(re.sub(
+        r'\s+', ' ',
+        next(iter(re.findall(r'<title>([^<]+)</title>', webpage)), ''),
+    ))).strip()
+    return title or fallback
+
+
+def _h1_text(webpage, fallback):
+    h1 = next(iter(re.findall(
+        r'<h1[^>]*class="title(?:_video)?"[^>]*>([\s\S]*?)</h1>', webpage)), '')
+    h1 = re.sub(r'<span\s+class="total_results">[^<]+</span>', '', h1)
+    return clean_html(re.sub(r'\s+', ' ', h1)).strip() or fallback
+
+
+class Rule34VideoPlaylistIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:playlist'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/playlists/(?P<id>\d+)(?:/[^/?#]*)?/?'
+    _TESTS = [{
+        'url': 'https://rule34video.com/playlists/124556/2d-animations27/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        webpage = self._download_webpage(url, playlist_id)
+        title = _h1_text(webpage, playlist_id)
+        return self.playlist_result(
+            self._video_entries(url, playlist_id, first_page=webpage),
+            playlist_id, title)
+
+
+class Rule34VideoModelIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:model'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/models/(?P<id>[a-z0-9\-]+)/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/models/seejaydj/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        slug = self._match_id(url)
+        return self.playlist_result(
+            self._video_entries(url, slug), slug, slug)
+
+
+class Rule34VideoCategoryIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:category'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/categories/(?P<id>[a-z0-9\-]+)/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/categories/2d/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        slug = self._match_id(url)
+        return self.playlist_result(
+            self._video_entries(url, slug), slug, slug)
+
+
+class Rule34VideoTagIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:tag'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/tags/(?P<id>\d+)/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/tags/1877/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        tag_id = self._match_id(url)
+        return self.playlist_result(
+            self._video_entries(url, tag_id), tag_id, f'tag-{tag_id}')
+
+
+class Rule34VideoMemberUploadsIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:member:uploads'
+    # Match both the bare profile and the explicit /videos/ tab. The bare
+    # profile renders extra cards (sidebar suggestions) - paginating the
+    # canonical /videos/ tab keeps results uniform.
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/members/(?P<id>\d+)(?:/videos)?/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/members/180930/videos/',
+        'only_matching': True,
+    }, {
+        'url': 'https://rule34video.com/members/180930/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        member_id = self._match_id(url)
+        videos_url = f'{_BASE}/members/{member_id}/videos/'
+        webpage = self._download_webpage(videos_url, member_id)
+        username = _title_text(webpage, member_id).removesuffix("'s Videos")
+        return self.playlist_result(
+            self._video_entries(videos_url, member_id, first_page=webpage),
+            member_id, f"{username}'s Videos",
+            uploader=username, uploader_id=member_id, uploader_url=videos_url)
+
+
+class Rule34VideoMemberFavoritesIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:member:favorites'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/members/(?P<id>\d+)/favourites/videos/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/members/98965/favourites/videos/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        member_id = self._match_id(url)
+        return self.playlist_result(
+            self._video_entries(url, member_id),
+            f'{member_id}-favorites', f'member-{member_id}-favorites')
+
+
+class Rule34VideoMemberPlaylistsIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:member:playlists'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/members/(?P<id>\d+)/playlists/?(?:\?|$)'
+    _TESTS = [{
+        'url': 'https://rule34video.com/members/180930/playlists/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        member_id = self._match_id(url)
+        return self.playlist_result(
+            self._playlist_entries(url, member_id),
+            f'{member_id}-playlists', f'member-{member_id}-playlists')
+
+
+class Rule34VideoSearchIE(_Rule34VideoListBaseIE):
+    IE_NAME = 'rule34video:search'
+    # Three shapes from the site: /search/<query>/, /search/?<filters>, and
+    # /search/<query>/?<filters>. The path query is hyphenated (spaces ->
+    # dashes), filters are repeated `tag_ids`, `category_ids`, `model_ids`.
+    _VALID_URL = (
+        r'https?://(?:www\.)?rule34video\.com/search/'
+        r'(?:(?P<id>[^/?#]+)/?)?(?:\?(?P<query>[^#]+))?')
+    _TESTS = [{
+        'url': 'https://rule34video.com/search/ayaka/',
+        'only_matching': True,
+    }, {
+        'url': 'https://rule34video.com/search/?model_ids=283',
+        'only_matching': True,
+    }, {
+        'url': 'https://rule34video.com/search/?tag_ids=all,423&category_ids=all,2',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        m = self._match_valid_url(url)
+        path_query = m.group('id') or ''
+        filter_query = m.group('query') or ''
+        playlist_id = urllib.parse.unquote(path_query) or filter_query or 'search'
+        # Search pagination needs both `from_videos` and `from_albums`. The
+        # site sends them as the same number but rejects requests with only
+        # one of them, so we mirror them.
+        return self.playlist_result(
+            self._video_entries(
+                url, playlist_id,
+                async_pagination_keys=('from_videos', 'from_albums')),
+            playlist_id, playlist_id)
+
+
+class _Rule34VideoMyBaseIE(_Rule34VideoListBaseIE):
+    """The /my/* tabs require auth cookies. The site redirects anonymous
+    requests to `/?login` while still returning 200, so detect the final
+    URL and raise a clear error instead of silently extracting the homepage.
+    """
+    _PATH = ''
+    _PLAYLIST_ID = ''
+
+    def _real_extract(self, url):
+        _, urlh = self._download_webpage_handle(url, self._PLAYLIST_ID)
+        if '/my/' not in urlh.url:
+            raise ExtractorError(
+                f'{self._PATH} requires login. Pass --cookies or '
+                '--cookies-from-browser', expected=True)
+        return self.playlist_result(
+            self._entries(url), self._PLAYLIST_ID, self._PLAYLIST_ID)
+
+    def _entries(self, url):  # pragma: no cover - subclasses override
+        raise NotImplementedError
+
+
+class Rule34VideoMyFavoritesIE(_Rule34VideoMyBaseIE):
+    IE_NAME = 'rule34video:my:favorites'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/my/favourites/videos/?(?:\?|$)'
+    _PATH = '/my/favourites/videos/'
+    _PLAYLIST_ID = 'my-favorites'
+    _TESTS = [{
+        'url': 'https://rule34video.com/my/favourites/videos/',
+        'only_matching': True,
+    }]
+
+    def _entries(self, url):
+        return self._video_entries(url, self._PLAYLIST_ID)
+
+
+class Rule34VideoMyVideosIE(_Rule34VideoMyBaseIE):
+    IE_NAME = 'rule34video:my:videos'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/my/videos/?(?:\?|$)'
+    _PATH = '/my/videos/'
+    _PLAYLIST_ID = 'my-videos'
+    _TESTS = [{
+        'url': 'https://rule34video.com/my/videos/',
+        'only_matching': True,
+    }]
+
+    def _entries(self, url):
+        return self._video_entries(url, self._PLAYLIST_ID)
+
+
+class Rule34VideoMyHistoryIE(_Rule34VideoMyBaseIE):
+    IE_NAME = 'rule34video:my:history'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/my/history/?(?:\?|$)'
+    _PATH = '/my/history/'
+    _PLAYLIST_ID = 'my-history'
+    _TESTS = [{
+        'url': 'https://rule34video.com/my/history/',
+        'only_matching': True,
+    }]
+
+    def _entries(self, url):
+        return self._video_entries(url, self._PLAYLIST_ID)
+
+
+class Rule34VideoMySubscriptionsIE(_Rule34VideoMyBaseIE):
+    IE_NAME = 'rule34video:my:subscriptions'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/my/subscriptions/?(?:\?|$)'
+    _PATH = '/my/subscriptions/'
+    _PLAYLIST_ID = 'my-subscriptions'
+    _TESTS = [{
+        'url': 'https://rule34video.com/my/subscriptions/',
+        'only_matching': True,
+    }]
+
+    def _entries(self, url):
+        return self._video_entries(url, self._PLAYLIST_ID)
+
+
+class Rule34VideoMyPlaylistsIE(_Rule34VideoMyBaseIE):
+    IE_NAME = 'rule34video:my:playlists'
+    _VALID_URL = r'https?://(?:www\.)?rule34video\.com/my/playlists/?(?:\?|$)'
+    _PATH = '/my/playlists/'
+    _PLAYLIST_ID = 'my-playlists'
+    _TESTS = [{
+        'url': 'https://rule34video.com/my/playlists/',
+        'only_matching': True,
+    }]
+
+    def _entries(self, url):
+        return self._playlist_entries(url, self._PLAYLIST_ID)


### PR DESCRIPTION
rule34video.com videos are already supported by upstream, but adding playlist and tag and search and the like.

the tests/ folder contains some end to end tests, i find them useful but may be discarded, i see you are currently not using this type of tests.