### PR TITLE
Fix hstream downloader for certain videos

### DIFF
--- a/yt_dlp_plugins/extractor/hstream.py
+++ b/yt_dlp_plugins/extractor/hstream.py
@@ -53,9 +53,25 @@ class HstreamIE(InfoExtractor):
             formats.extend(results)
 
         poster_url = '{}/{}'.format('https://hstream.moe', video.get('poster'))
+
+        subtitles = {}
+        subtitles['en'] = [{
+            'url': f'{cdn_url}/eng.ass',
+            'ext': 'ass'
+        }]
+
+        extra_subtitles = video.get('extra_subtitles') or {}
+        for lang in extra_subtitles:
+            if lang != 'en':
+                subtitles[lang] = [{
+                    'url': f'{cdn_url}/autotrans/{lang}.ass',
+                    'ext': 'ass'
+                }]
+
         return {
             'id': e_id,
             'title': video.get('title'),
             'thumbnail': poster_url,
-            'formats': formats
+            'formats': formats,
+            'subtitles': subtitles
         }

--- a/yt_dlp_plugins/extractor/hstream.py
+++ b/yt_dlp_plugins/extractor/hstream.py
@@ -32,12 +32,71 @@ class HstreamIE(InfoExtractor):
 
         # NOTE Although all CDNs essentially provide same resources, based on the client's
         # country, the speeds may differ.
-        cdn_url = '{}/{}'.format(video['stream_domains'][0], video['stream_url'])
+        stream_domains = video.get('stream_domains') or []
+        domains = [domain.rstrip('/') for domain in stream_domains if domain]
+
+        if domains:
+            orig_urlopen = self._downloader.urlopen
+            current_domain = [domains[0]]
+
+            def custom_urlopen(req, *args, **kwargs):
+                url_str = req if isinstance(req, str) else req.url
+                
+                matched_domain = None
+                for domain in domains:
+                    if domain in url_str:
+                        matched_domain = domain
+                        break
+                
+                if not matched_domain:
+                    return orig_urlopen(req, *args, **kwargs)
+                
+                active_domain = current_domain[0]
+                if matched_domain != active_domain:
+                    url_str = url_str.replace(matched_domain, active_domain, 1)
+                    matched_domain = active_domain
+                    if not isinstance(req, str):
+                        req.url = url_str
+                
+                try:
+                    start_idx = domains.index(matched_domain)
+                except ValueError:
+                    start_idx = 0
+                
+                ordered_domains = domains[start_idx:] + domains[:start_idx]
+                
+                last_err = None
+                for domain in ordered_domains:
+                    new_url = url_str.replace(matched_domain, domain, 1)
+                    
+                    if isinstance(req, str):
+                        test_req = new_url
+                    else:
+                        req.url = new_url
+                        test_req = req
+                    
+                    try:
+                        self.to_screen(f'[hstream] Trying CDN download link: {new_url}')
+                        res = orig_urlopen(test_req, *args, **kwargs)
+                        current_domain[0] = domain
+                        return res
+                    except Exception as err:
+                        self.report_warning(f'[hstream] Failed to download from {new_url}: {err}')
+                        last_err = err
+                        continue
+                
+                if last_err:
+                    raise last_err
+                raise Exception("All stream domains failed")
+
+            self._downloader.urlopen = custom_urlopen
+
+        cdn_url = '{}/{}'.format(domains[0] if domains else video['stream_domains'][0], video['stream_url'])
         formats = []
         
         for res in ('720', '1080', '2160'):
             results = self._extract_mpd_formats('{}/{}/manifest.mpd'.format(cdn_url, res),
-                                                video_id, mpd_id=res)
+                                                 video_id, mpd_id=res)
 
             formats.extend(results)
 

--- a/yt_dlp_plugins/extractor/hstream.py
+++ b/yt_dlp_plugins/extractor/hstream.py
@@ -32,7 +32,18 @@ class HstreamIE(InfoExtractor):
 
         # NOTE Although all CDNs essentially provide same resources, based on the client's
         # country, the speeds may differ.
-        cdn_url = '{}/{}'.format(video['stream_domains'][0], video['stream_url'])
+        orig_urlopen = self._downloader.urlopen
+
+        def _urlopen_with_normalized_path(req, *args, **kwargs):
+            if isinstance(req, str):
+                req = req.replace('\\', '/').replace('%5C', '/').replace('%5c', '/')
+            elif hasattr(req, 'url') and isinstance(req.url, str):
+                req.url = req.url.replace('\\', '/').replace('%5C', '/').replace('%5c', '/')
+            return orig_urlopen(req, *args, **kwargs)
+
+        self._downloader.urlopen = _urlopen_with_normalized_path
+
+        cdn_url = '{}/{}'.format(video['stream_domains'][0], video['stream_url']).replace('\\', '/')
         formats = []
         
         for res in ('720', '1080', '2160'):


### PR DESCRIPTION
Fixed hstream.py to circumvent yt-dlp path normalization for manifests

Here is a problematic video
[Example 1](https://hstream.moe/hentai/energy-kyouka-2)

The fix was replace the URL encode character %5C to a / when downloading